### PR TITLE
Add trailing slash to /profiles endpoint

### DIFF
--- a/Profiles.md
+++ b/Profiles.md
@@ -42,7 +42,7 @@ This endpoint displays a list of profiles associated to an organisation.
 
 ##### Endpoints:
 
-`GET /profiles`
+`GET /profiles/`
 
 ##### Headers
 `Content-Type`: application/vnd.api+json


### PR DESCRIPTION
Add trailing slash to `/profiles` endpoint description.

Currently "List All Profiles" request requires a trailing slash to be added to the endpoint `/profiles` for request to actually work.

The example adds the trailing slash, but definition fails to mention this critical requirement.