### PR TITLE
Add missing '{' to create account response

### DIFF
--- a/Accounts.md
+++ b/Accounts.md
@@ -78,7 +78,7 @@ https://us-west-2-api.cloudconformity.com/v1/accounts
 Example Response:
 
 ```
-
+{
   "data": {
     "type": "accounts",
     "id": "H19NxMi5-",


### PR DESCRIPTION
The example of "Create an Account" response is missing an opening curly brace.

For people like myself, who want to crate automations with Cloud Conformity API, working examples of requests and responses make it easier to create mocks.