### PR TITLE
docs: PD-5749 update curl commands to include -g or --globoff

### DIFF
--- a/Checks.md
+++ b/Checks.md
@@ -595,7 +595,7 @@ The table below give more information about filter options:
 Example Request:
 
 ```
-curl -H "Content-Type: application/vnd.api+json" \
+curl -g -H "Content-Type: application/vnd.api+json" \
 -H "Authorization: ApiKey S1YnrbQuWagQS0MvbSchNHDO73XHqdAqH52RxEPGAggOYiXTxrwPfmiTNqQkTq3p" \
 https://us-west-2-api.cloudconformity.com/v1/checks?accountIds=r1gyR4cqg&page[size]=100&page[number]=0&filter[regions]=us-west-2&filter[ruleIds]=EC2-001,EC2-002&filter[statuses]=SUCCESS&filter[categories]=security&filter[riskLevels]=HIGH&filter[services]=EC2&filter[createdDate]=1502572157914
 ```

--- a/Events.md
+++ b/Events.md
@@ -53,7 +53,7 @@ The table below give more information about filter options:
 For example, the following is a request for static-deployer events within a specified time frame on one account:
 
 ```
-curl -H "Content-Type: application/vnd.api+json" \
+curl -g -H "Content-Type: application/vnd.api+json" \
      -H "Authorization: ApiKey S1YnrbQuWagQS0MvbSchNHDO73XHqdAqH52RxEPGAggOYiXTxrwPfmiTNqQkTq3p" \
      https://us-west-2-api.cloudconformity.com/v1/events?accountIds=ryi9NPivK&filter[identities]=static-deployer&filter[since]=1519919272016&filter[until]=1519932055819
 ```


### PR DESCRIPTION
This ticket updates the example requests for curl requests that include [] characters in the request url. Now they have an additional flag of -g or --globoff.

For reference check: https://ec.haxx.se/cmdline/cmdline-globbing