### PR TITLE
improve: PD-7756 create a schema for the checks entity

### DIFF
--- a/open-api/shared-schemas/account.yml
+++ b/open-api/shared-schemas/account.yml
@@ -75,9 +75,7 @@ properties:
     description: Status of the Conformity Bot for the account.
     example: RUNNING
   cloud-type:
-    type: string
-    enum: [aws, azure]
-    description: Cloud provider that the rule applies to.
+    $ref: ./provider.yml
   managed-group-id:
     type: string
     description: ID of the managed group.

--- a/open-api/shared-schemas/categories.yml
+++ b/open-api/shared-schemas/categories.yml
@@ -1,0 +1,11 @@
+type: array
+example: [security]
+items:
+  type: string
+  description: An array of category (AWS well-architected framework category) strings.
+  enum:
+    - security
+    - cost-optimisation
+    - reliability
+    - performance-efficiency
+    - operational-excellence

--- a/open-api/shared-schemas/check.yml
+++ b/open-api/shared-schemas/check.yml
@@ -1,0 +1,212 @@
+type: object
+properties:
+  type:
+    type: string
+    description: Name of the data type.
+    example: checks
+  id:
+    type: string
+    description: Id of the check.
+    example: ccc:H19NxM15-:CUSTOM-001:EC2:us-west-2:sg-956d00ea
+  attributes:
+    type: object
+    properties:
+      accountId:
+        type: string
+        description: Id of the account the check was generated for.
+        example: FJagHgv1g
+      categories:
+        $ref: ./categories.yml
+      compliances:
+        $ref: ./compliance-standards.yml
+      cost:
+        type: number
+        description: Estimated cost (USD) of the resource this check applies to (if applicable).
+        example: 3.1968
+      created-date:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date that the check was created.
+        example: 1521660152755
+      descriptorType:
+        type: string
+        description: The type of descriptor used by the check.
+        example: s3-bucket
+      eventId:
+        type: string
+        description: Conformity identifier for the event that triggered RTM to generate the check.
+        example: Skzp7ra1WW
+      excluded:
+        type: boolean
+        description: true when the checks resource matches the rule exceptions setting.
+        example: false
+      extradata:
+        type: array
+        description: Additional data for the check.
+        items:
+          type: object
+          properties:
+            label:
+              type: string
+              description: Text to describe the data.
+              maxLength: 20
+              example: Group Id
+            name:
+              type: string
+              description: Conformity internal reference for the data ("Resource" is the default value for this).
+              maxLength: 20
+              example: GroupId
+            type:
+              type: string
+              description: The type of the extra data.
+              maxLength: 20
+              example: META
+            value:
+              oneOf:
+                - type: string
+                  maxLength: 150
+                - type: number
+                  maxLength: 150
+                - type: object
+                - type: boolean
+                - type: array
+                  items: {}
+              example: sg-2e885d00
+      failure-discovery-date:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the failure was discovered on.
+        example: 1521660152755
+      failure-introduced-by:
+        type: string
+        description:
+          The cloud provider or Conformity user identifier of the user that caused the event that triggered
+          RTM to transition the check state to failure.
+        example: someone@test.com
+      ignored:
+        type: boolean
+        description: true when check is to be ignored.
+        example: false
+      last-updated-date:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the check was last updated.
+        example: 1521660152755
+      last-updated-by:
+        type: string
+        description:
+          The cloud provider or Conformity user identifier of the user that caused the event that triggered
+          RTM to generate the check.
+        example: someone@test.com
+      last-modified-date:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the check was last modified.
+        example: 1521660152755
+      lastStatusUpdateDate:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the checks status was last updated.
+        example: 1521660152755
+      link:
+        type: string
+        description: Link to the resource the check refers to.
+        example: https://s3.console.aws.amazon.com/s3/buckets/gm-bucket-4/?region=us-east-1&tab=overview
+      link-title:
+        type: string
+        description: Title of the resource linked to.
+        example: gm-bucket-4
+      message:
+        type: string
+        description: Description of the check.
+        example: Bucket S3Bucket allows public 'READ' access.
+      not-scored:
+        type: boolean
+        description: true for informational checks.
+        example: false
+      notes:
+        $ref: ./types/notes.yml
+      organisationId:
+        type: string
+        description: Id of the organisation the check was generated for.
+        example: F1r9_41ul
+      pretty-risk-level:
+        type: string
+        description: Human readable version of the risk level of the Conformity rule.
+        enum: [Low, Medium, High, Very High, Extreme, Unknown]
+        example: Medium
+      provider:
+        $ref: ./provider.yml
+      providerResourceId:
+        type: string
+        description: Cloud provider id of the resource the check was generated for (e.g. ARN in AWS).
+        example: arn:aws:sns:us-east-1:123456789012:MyTopic
+      region:
+        type: string
+        description: The region the check ran in.
+        example: us-west-2
+      resolved-date:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the check was resolved.
+        example: 1521660152755
+      resolved-by:
+        type: string
+        description:
+          The cloud provider or Conformity user identifier of the user that caused the event that triggered
+          RTM to resolve the check.
+        example: someone@test.com
+      resolution-page-url:
+        type: string
+        description: Custom defined resolution page url.
+        example: https://www.cloudconformity.com/conformity-rules/IAM/unused-iam-group.html#
+      resource:
+        type: string
+        description: The resource this check applies to.
+        example: S3Bucket
+      resourceName:
+        type: string
+        description: The type of resource this check applies to.
+        example: KeyVault Vault
+      risk-level:
+        $ref: ./risk-level.yml
+      rule-title:
+        type: string
+        description: rule title.
+        example: Custom Rule about EC2 SGs
+        default: Custom Rule
+      service:
+        type: string
+        description: The cloud provider service name.
+        example: S3
+      status:
+        type: string
+        description: The status of the check.
+        enum:
+          - SUCCESS
+          - FAILURE
+        example: SUCCESS
+      suppressed:
+        type: boolean
+        description: true if the check has been suppressed.
+        example: true
+      suppressed-until:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date the checks is suppressed until.
+        example: 1521660152755
+      tags:
+        type: array
+        description: 'an array of tag strings that follow the format: "key::value"'
+        items:
+          type: string
+        example: ["key0::value0", "key1::value1"]
+      ttl:
+        type: number
+        description: A date-time in Unix Epoch timestamp format (in milliseconds)
+          which is the date that the check will be deleted.
+        example: 1521660152755
+      waste:
+        type: number
+        description: Estimated cost saving (USD) for the resource if the failed check is resolved (if applicable).
+        example: 54.32

--- a/open-api/shared-schemas/checks-response.yml
+++ b/open-api/shared-schemas/checks-response.yml
@@ -1,0 +1,33 @@
+type: array
+items:
+  allOf:
+    - $ref: ./check.yml
+    - type: object
+      properties:
+        relationships:
+          type: object
+          properties:
+            rule:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      example: rules
+                    id:
+                      type: string
+                      example: CUSTOM-001
+            account:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      example: accounts
+                    id:
+                      type: string
+                      example: H19NxM15-

--- a/open-api/shared-schemas/compliance-standard-id.yml
+++ b/open-api/shared-schemas/compliance-standard-id.yml
@@ -1,0 +1,21 @@
+type: array
+example: [AWAF]
+items:
+  type: string
+  description: An array of supported standard or framework ids.
+  enum:
+    - AWAF
+    - CISAWSF
+    - CISAZUREF
+    - CISAWSTTW
+    - PCI
+    - HIPAA
+    - GDPR
+    - APRA
+    - NIST4
+    - SOC2
+    - NIST-CSF
+    - ISO27001
+    - AGISM
+    - ASAE-3150
+    - MAS

--- a/open-api/shared-schemas/compliance-standards.yml
+++ b/open-api/shared-schemas/compliance-standards.yml
@@ -1,0 +1,21 @@
+type: array
+example: [AWAF]
+items:
+  type: string
+  description: An array of supported standard or framework ids.
+  enum:
+    - AWAF
+    - CISAWSF
+    - CISAZUREF
+    - CISAWSTTW
+    - PCI
+    - HIPAA
+    - GDPR
+    - APRA
+    - NIST4
+    - SOC2
+    - NIST-CSF
+    - ISO27001
+    - AGISM
+    - ASAE-3150
+    - MAS

--- a/open-api/shared-schemas/filter.yml
+++ b/open-api/shared-schemas/filter.yml
@@ -77,42 +77,11 @@ properties:
     description: Only show checks created less than X days ago.
     example: 5
   categories:
-    type: array
-    example: [security]
-    items:
-      type: string
-      description: An array of category (AWS well-architected framework category) strings.
-      enum:
-        [security, cost-optimisation, reliability, performance-efficiency, operational-excellence]
+    $ref: ./categories.yml
   riskLevels:
-    type: string
-    description: Risk level.
-    enum: [EXTREME, VERY_HIGH, HIGH, MEDIUM, LOW]
-    example: EXTREME
+    $ref: ./risk-level.yml
   complianceStandards:
-    type: array
-    example: [AWAF]
-    items:
-      type: string
-      description: An array of supported standard or framework ids.
-      enum:
-        [
-          AWAF,
-          CISAWSF,
-          CISAZUREF,
-          CISAWSTTW,
-          PCI,
-          HIPAA,
-          GDPR,
-          APRA,
-          NIST4,
-          SOC2,
-          NIST-CSF,
-          ISO27001,
-          AGISM,
-          ASAE-3150,
-          MAS,
-        ]
+    $ref: ./compliance-standards.yml
   reportComplianceStandardId:
     type: string
     description: A single standard or framework id string.

--- a/open-api/shared-schemas/risk-level.yml
+++ b/open-api/shared-schemas/risk-level.yml
@@ -1,4 +1,9 @@
 type: string
 description: Risk level of the Conformity rule.
-enum: [LOW, MEDIUM, HIGH, VERY_HIGH, EXTREME]
+enum:
+  - LOW
+  - MEDIUM
+  - HIGH
+  - VERY_HIGH
+  - EXTREME
 example: MEDIUM

--- a/open-api/shared-schemas/rule.yml
+++ b/open-api/shared-schemas/rule.yml
@@ -17,22 +17,9 @@ properties:
     description: Rule title
     example: Security Group Port Range
   categories:
-    type: array
-    items:
-      type: string
-      description: category that the rule belongs to.
-      enum:
-        [
-          "security",
-          "cost-optimisation",
-          "reliability",
-          "performance-efficiency",
-          "operational-excellence",
-        ]
+    $ref: "./categories.yml"
   risk-level:
-    type: string
-    description: Configures the level of risk assigned to the rule.
-    enum: ["EXTREME", "VERY_HIGH", "HIGH", "MEDIUM", "LOW"]
+    $ref: "./risk-level.yml"
   multi-risk-level:
     type: boolean
     description: Determines whether a rule has multiple risk levels for each setting.

--- a/open-api/shared-schemas/rules-response.yml
+++ b/open-api/shared-schemas/rules-response.yml
@@ -44,23 +44,7 @@ properties:
     type: object
     properties:
       notes:
-        type: array
-        description: List of notes for the rule.
-        items:
-          type: object
-          properties:
-            createdBy:
-              type: string
-              description: ID of the user who has created the note.
-              example: "SYmS0YcL-"
-            createdDate:
-              type: integer
-              description: A date-time in Unix Epoch timestamp format (in milliseconds) which indicates when the note has been created.
-              example: 1511456432526
-            note:
-              type: string
-              description: Note added to the rule.
-              example: hello world
+        $ref: "./types/notes.yml"
 example:
   data:
     type: accounts
@@ -120,3 +104,8 @@ example:
         data:
           type: organisations
           id: B1nHYYpwx
+    meta:
+      notes:
+        - createdBy: SYmS0YcL-
+          createdDate: 1511456432526
+          note: hello world

--- a/open-api/shared-schemas/types/notes.yml
+++ b/open-api/shared-schemas/types/notes.yml
@@ -1,0 +1,18 @@
+type: array
+description: List of notes.
+items:
+  type: object
+  properties:
+    createdBy:
+      type: string
+      description: ID of the user who has created the note.
+      example: SYmS0YcL-
+    createdDate:
+      type: number
+      description: A date-time in Unix Epoch timestamp format (in milliseconds) which
+        is when the note has been created.
+      example: 1511456432526
+    note:
+      type: string
+      description: Note added to the rule.
+      example: hello world

--- a/open-api/template-scanner/scan/post/responses/200.yml
+++ b/open-api/template-scanner/scan/post/responses/200.yml
@@ -1,4 +1,4 @@
 type: object
 properties:
   data:
-    $ref: ../../../../shared-schemas/rules-response.yml
+    $ref: ../../../../shared-schemas/checks-response.yml


### PR DESCRIPTION
This schema isn't complete as there is quite a few outstanding details inside the check that still need to be given descriptions and examples.

I'm hoping this PR can be used to collaborate on trying to find descriptions and examples of all of the items in the entity.

Items that still require descriptions and examples added:

- [x] ~1. ccrn~ Not a part of the official API
- [x] 2. compliances - credit @togleid 
- [x] 3. cost
- [x] 4. eventId
- [x] 5. excluded - credit @ethankhoa 
- [x] 6. extradata
- [x] ~7. extradataHash~ Not a part of the official API, internal use only
- [x] 8. failure-introduced-by
- [x] 9. last-updated-by 
- [x] ~10. lastModifiedBy~ Not a part of the official API
- [x] 11. link - credit @togleid 
- [x] 12. link-title - credit @togleid 
- [x] 13. notes
- [x] ~14. origin~ Not a part of the official API
- [x] 15. providerResourceId
- [x] 16. resolved-by
- [x] ~17. resolution-due-date~ Unused field
- [x] ~18. ruleId~ Removed as it is present in relationships
- [x] ~19. score~ Unused field
- [x] 20. service
- [x] ~21. statusRiskLevel~ Unused field
- [x] ~22. ticket~ Removed from the model, should be accessible from a separate endpoint
- [x] ~23. tickets~ Removed from the model, should be accessible from a separate endpoint
- [x] 24. ttl
- [x] 25. waste
- [ ] Add disclaimer for non-official fields