### PR TITLE
fix: Docs: PD-7394-PD-7925 - fix punctuation

### DIFF
--- a/open-api/organisation/external-id/get/index.yml
+++ b/open-api/organisation/external-id/get/index.yml
@@ -1,6 +1,6 @@
 summary: Get External ID
 description: This endpoint allows you to get your organisation's external ID.
-  <br> *note The endpoint will return an error if no accounts have previously been added to the organisation.*
+  <br> **note**&#58; *The endpoint will return an error if no accounts have previously been added to the organisation.*
 tags:
   - Organisations
   - External IDs


### PR DESCRIPTION
added colon and bolded "note".
changed from:
_note The endpoint will return an error if no accounts have previously been added to the organisation._
to:
**note**: _The endpoint will return an error if no accounts have previously been added to the organisation._


Screenshot of change:
<img width="643" alt="Cloud Conformity 2020-10-20 09-58-07" src="https://user-images.githubusercontent.com/46974827/96520632-36a68880-12bb-11eb-93f2-7b790042b61b.png">
